### PR TITLE
Fix cross-region character search

### DIFF
--- a/src/search/character-search.ts
+++ b/src/search/character-search.ts
@@ -12,6 +12,8 @@ export class CharacterSearch extends PaginatedPageParser {
       query += `&worldname=_dc_${req.query.dc}`;
     } else if (req.query.server) {
       query += `&worldname=${req.query.server}`;
+    } else {
+      query += '&worldname=';
     }
     return `https://na.finalfantasyxiv.com/lodestone/character/${query}`;
   }


### PR DESCRIPTION
With the recent Lodestone update, if the `worldname` parameter is completely omitted in character search, only the region specified in the domain is searched. This PR fixes it by adding a blank `worldname` query parameter if no server or DC is specified, which forces search in all regions.